### PR TITLE
Update .gitignore to exclude hidden folders and IDE config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,35 @@ logs/
 tokens.json
 credentials.json
 auth.json
+
+# Added by Claude Task Master
+# Logs
+logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+dev-debug.log
+# Dependency directories
+node_modules/
+# Environment variables
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+# OS specific
+
+# Task files
+# tasks.json
+# tasks/
+
+# Hidden folders (all folders starting with .)
+.*/
+
+# IDE and tool-specific files
+.roomodes
+.taskmasterconfig
+.windsurfrules 


### PR DESCRIPTION
## Summary
- Add pattern to ignore all hidden folders (.*)
- Add specific IDE and tool config files (.roomodes, .taskmasterconfig, .windsurfrules)
- Keep existing Python and project-specific ignores

## Test plan
- [x] Verified .gitignore syntax is valid
- [x] Confirmed hidden folders will be ignored
- [x] Ensured important files like .env.example are not ignored